### PR TITLE
New method to allow cache cleaning

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/util/DuckType.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/util/DuckType.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,6 +66,15 @@ public class DuckType
     }
 
     protected static final Object NO_METHOD = new Object();
+
+    /**
+     * Clears the internal cache of all the underlying Types.
+     */
+    public static void clearCache() {
+        for(Types type : Types.values()) {
+            type.cache.clear();
+        }
+    }
 
     public static String asString(Object value)
     {


### PR DESCRIPTION
Hi,

I suggest to add a method in `DuckType` to clean the underlying cache held by the protected class `Types`. Actually, those caches could grow pretty big, depending of the number of classes.

In our case, we have a special ClassLoader that allows us reloading classes during the runtime. Those classes will then be used in velocity templates, resulting in a memory leak (because the libraries are not reloaded within the same ClassLoader).

Best regards,
Cédric