### PR TITLE
don't leak classes via Stop.STOP_ALL stack trace

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/directive/Stop.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/directive/Stop.java
@@ -36,7 +36,12 @@ import java.util.ArrayList;
  */
 public class Stop extends Directive
 {
-    private static final StopCommand STOP_ALL = new StopCommand("StopCommand to exit merging");
+    private static final StopCommand STOP_ALL = new StopCommand("StopCommand to exit merging") {
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    };
 
     private boolean hasMessage = false;
 


### PR DESCRIPTION
this prevented garbage-collecting classloaders that accidentally happened to be in the stack trace when Stop class was first accessed

This prevents plugin unloading in IntelliJ: https://youtrack.jetbrains.com/issue/IDEA-240449