### PR TITLE
core: update the version of commons-io

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ plus the following ones, needed for the integrated tests:
 * slf4j-simple v1.7.30
 * junit v4.13
 * hsqldb v2.5.0
-* commons-io 2.6
+* commons-io 2.8.0
 
 At runtime, Velocity only needs:
 

--- a/velocity-custom-parser-example/pom.xml
+++ b/velocity-custom-parser-example/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There is a vulnerability CVSS V2: 7.1/AV:N/AC:M/Au:N/C:N/I:N/A:C fixed by [commit](https://github.com/apache/commons-io/commit/97ae01c95837f50a2e9be34c370b271c4d8fc88b) to commons-io which is shaded into the final jar for velocity. Upgrading version to remove vulnerability.