### PR TITLE
add the ability to override defaultEncoding

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/RuntimeInstance.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/RuntimeInstance.java
@@ -733,6 +733,9 @@ public class RuntimeInstance implements RuntimeConstants, RuntimeServices
         if( overridingProperties != null )
         {
             configuration.combine(overridingProperties);
+
+            /* reinitialize defaultEncoding in case it is overridden */
+            defaultEncoding = getString(INPUT_ENCODING, ENCODING_DEFAULT);
         }
     }
 

--- a/velocity-engine-core/src/test/java/org/apache/velocity/runtime/RuntimeInstanceTest.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/runtime/RuntimeInstanceTest.java
@@ -1,0 +1,49 @@
+package org.apache.velocity.runtime;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.velocity.exception.ParseErrorException;
+import org.apache.velocity.exception.ResourceNotFoundException;
+import org.apache.velocity.runtime.resource.Resource;
+import org.apache.velocity.runtime.resource.ResourceManager;
+import org.junit.Test;
+
+public class RuntimeInstanceTest {
+
+    @Test
+    public void givenOverridenInputEncoding_whenInitializing_defaultEncodingIsOverridden() {
+        RuntimeInstance instance = new RuntimeInstance();
+        MockResourceManager manager = new MockResourceManager();
+        String value = "testDummyEncoding";
+        instance.addProperty(RuntimeConstants.INPUT_ENCODING, value);
+        instance.addProperty(RuntimeConstants.RESOURCE_MANAGER_INSTANCE, manager);
+        instance.init();
+
+        instance.getTemplate("some template");
+
+        assertEquals(value, manager.encoding);
+
+    }
+
+    class MockResourceManager implements ResourceManager {
+
+        String encoding = null;
+
+        @Override
+        public String getLoaderNameForResource(String resourceName) {
+            return null;
+        }
+
+        @Override
+        public Resource getResource(String resourceName, int resourceType, String encoding)
+                throws ResourceNotFoundException, ParseErrorException {
+            this.encoding = encoding;
+            return null;
+        }
+
+        @Override
+        public void initialize(RuntimeServices rs) {
+
+        }
+    }
+}


### PR DESCRIPTION
the defaultEncoding used by runtime instance is not overridable. currently it is loaded on initialization of RuntimeInstance from the default configuration object without taking overridingProperties into account.

by this change, after merging overridingProperties into RuntimeInstance#configuration the defaultEncoding gets reinitialized.