### PR TITLE
Fixes VELOCITY-953

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/directive/VelocimacroProxy.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/directive/VelocimacroProxy.java
@@ -216,8 +216,6 @@ public class VelocimacroProxy extends Directive
             // render the velocity macro
             context.pushCurrentMacroName(macroName);
             nodeTree.render(context, writer);
-            context.popCurrentMacroName();
-            return true;
         }
         catch (RuntimeException e)
         {
@@ -231,6 +229,11 @@ public class VelocimacroProxy extends Directive
         }
         finally
         {
+            // if MacroOverflowException was thrown then it already empties the stack
+            // for everything else - e.g. other exceptions - we clean up after ourself
+            if (context.getCurrentMacroCallDepth() > 0)
+                context.popCurrentMacroName();
+
             // clean up after the args and bodyRef
             // but only if they weren't overridden inside
             Object current = context.get(bodyReference);
@@ -283,6 +286,8 @@ public class VelocimacroProxy extends Directive
                 }
             }
         }
+            
+        return true;
     }
 
     /**


### PR DESCRIPTION
VelocimacroProxy polutes context stack due to wrong handling of #break or exceptions.

First PR failed testing. This one adds a guard due to MacroOverflowException already cleaning up the stack.