### PR TITLE
update dependencies to avoid CVE warnings

### DIFF
--- a/velocity-engine-core/pom.xml
+++ b/velocity-engine-core/pom.xml
@@ -49,7 +49,7 @@
         -->
         <test.jdbc.driver.groupId>org.hsqldb</test.jdbc.driver.groupId>
         <test.jdbc.driver.artifactId>hsqldb</test.jdbc.driver.artifactId>
-        <test.jdbc.driver.version>2.5.1</test.jdbc.driver.version>
+        <test.jdbc.driver.version>2.7.1</test.jdbc.driver.version>
         <test.jdbc.driver.className>org.hsqldb.jdbcDriver</test.jdbc.driver.className>
         <test.jdbc.uri>jdbc:hsqldb:.</test.jdbc.uri>
         <test.jdbc.login>sa</test.jdbc.login>


### PR DESCRIPTION
Updates hsqldb to 2.7.1