### PR TITLE
hsqldb 'jdk8' dependency classifier

### DIFF
--- a/velocity-engine-core/pom.xml
+++ b/velocity-engine-core/pom.xml
@@ -50,6 +50,7 @@
         <test.jdbc.driver.groupId>org.hsqldb</test.jdbc.driver.groupId>
         <test.jdbc.driver.artifactId>hsqldb</test.jdbc.driver.artifactId>
         <test.jdbc.driver.version>2.7.1</test.jdbc.driver.version>
+        <test.jdbc.driver.classifier>jdk8</test.jdbc.driver.classifier>
         <test.jdbc.driver.className>org.hsqldb.jdbcDriver</test.jdbc.driver.className>
         <test.jdbc.uri>jdbc:hsqldb:.</test.jdbc.uri>
         <test.jdbc.login>sa</test.jdbc.login>
@@ -316,6 +317,7 @@
             <artifactId>${test.jdbc.driver.artifactId}</artifactId>
             <version>${test.jdbc.driver.version}</version>
             <scope>test</scope>
+            <classifier>${test.jdbc.driver.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
hsqldb 2.7.1 dependency without classifier has jdk 11 requirement.

either:
* upgrade project's min jdk version to 11 for tests
* add jdk8 classifier to dependency (suggested option)