### PR TITLE
update the resource.loader configuration key to resource.loaders when not used as a prefix

### DIFF
--- a/spring-velocity-support/src/main/java/org/apache/velocity/spring/VelocityEngineFactory.java
+++ b/spring-velocity-support/src/main/java/org/apache/velocity/spring/VelocityEngineFactory.java
@@ -276,7 +276,7 @@ public class VelocityEngineFactory {
 						resolvedPath.append(',');
 					}
 				}
-				velocityEngine.setProperty(RuntimeConstants.RESOURCE_LOADER, "file");
+				velocityEngine.setProperty(RuntimeConstants.RESOURCE_LOADERS, "file");
 				velocityEngine.setProperty(RuntimeConstants.FILE_RESOURCE_LOADER_CACHE, "true");
 				velocityEngine.setProperty(RuntimeConstants.FILE_RESOURCE_LOADER_PATH, resolvedPath.toString());
 			}
@@ -308,7 +308,7 @@ public class VelocityEngineFactory {
 	 */
 	protected void initSpringResourceLoader(VelocityEngine velocityEngine, String resourceLoaderPath) {
 		velocityEngine.setProperty(
-				RuntimeConstants.RESOURCE_LOADER, SpringResourceLoader.NAME);
+				RuntimeConstants.RESOURCE_LOADERS, SpringResourceLoader.NAME);
 		velocityEngine.setProperty(
 				SpringResourceLoader.SPRING_RESOURCE_LOADER_CLASS, SpringResourceLoader.class.getName());
 		velocityEngine.setProperty(


### PR DESCRIPTION
Since 2.1 the configuration key `resource.loader` has been deprecated in favor of `resource.loaders`.

This PR fixes a deprecation warning caused by the `spring-velocity-support` module, aligning the code with the rest of the code base.