### PR TITLE
VELOCITY-970: velocity-engine-core contains commons-io Maven descriptor

### DIFF
--- a/velocity-engine-core/pom.xml
+++ b/velocity-engine-core/pom.xml
@@ -192,7 +192,6 @@
                             org.apache.velocity.*
                         </Export-Package>
                         <Import-Package>
-                            !org.apache.commons.io,
                             *
                         </Import-Package>
                     </instructions>

--- a/velocity-engine-core/pom.xml
+++ b/velocity-engine-core/pom.xml
@@ -108,39 +108,6 @@
                 </executions>
             </plugin>
 
-            <!-- shading of commons-io -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>shade</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>commons-io:commons-io</include>
-                                </includes>
-                                <excludes>
-                                    <exclude>org.slf4j:slf4j-api</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.apache.commons.io</pattern>
-                                    <shadedPattern>org.apache.velocity.shaded.commons.io</shadedPattern>
-                                </relocation>
-                            </relocations>
-                            <minimizeJar>true</minimizeJar>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- parser -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Jira issue: https://issues.apache.org/jira/browse/VELOCITY-970

The idea is to remove commons-io from the velocity-engine-core JAR since there does not seem to be a clear reason to do that (it's not like it was the only dependency and commons-io is known to have a pretty good retro compatibility policy, but it's possible I missed another reason of course). In my case, it also causes problems with a tool in charge of identifying Maven artifacts in the classloader because it also embbed the Maven descriptor.