### PR TITLE
Change boxed primitive constructor calls to more modern equivalents.

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/MathUtils.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/MathUtils.java
@@ -31,13 +31,13 @@ import java.util.Map;
  *
  * All operations (+ - / *) return a Number which type is the type of the bigger argument.<br>
  * Example:<br>
- * <code>add ( new Integer(10), new Integer(1))</code> will return an <code>Integer</code>-Object with the value 11<br>
- * <code>add ( new Long(10), new Integer(1))</code> will return an <code>Long</code>-Object with the value 11<br>
- * <code>add ( new Integer(10), new Float(1))</code> will return an <code>Float</code>-Object with the value 11<br><br>
+ * <code>add ( Integer.valueOf(10), Integer.valueOf(1))</code> will return an <code>Integer</code>-Object with the value 11<br>
+ * <code>add ( Long.valueOf(10), Integer.valueOf(1))</code> will return an <code>Long</code>-Object with the value 11<br>
+ * <code>add ( Integer.valueOf(10), Float.valueOf(1))</code> will return an <code>Float</code>-Object with the value 11<br><br>
  *
  * Overflow checking:<br>
  * For integral values (byte, short, int) there is an implicit overflow correction (the next "bigger"
- * type will be returned). For example, if you call <code>add (new Integer (Integer.MAX_VALUE), 1)</code> a
+ * type will be returned). For example, if you call <code>add (Integer.valueOf(Integer.MAX_VALUE), 1)</code> a
  * <code>Long</code>-object will be returned with the correct value of <code>Integer.MAX_VALUE+1</code>.<br>
  * In addition to that the methods <code>multiply</code>,<code>add</code> and <code>substract</code> implement overflow
  * checks for <code>long</code>-values. That means that if an overflow occurs while working with long values a BigInteger

--- a/velocity-engine-core/src/main/java/org/apache/velocity/util/ExtProperties.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/util/ExtProperties.java
@@ -1923,7 +1923,7 @@ public class ExtProperties extends DeprecationAwareExtProperties
         }
         else if (value instanceof String)
         {
-            Float f = new Float((String) value);
+            Float f = Float.valueOf((String) value);
             put(key, f);
             return f;
 
@@ -2015,7 +2015,7 @@ public class ExtProperties extends DeprecationAwareExtProperties
         }
         else if (value instanceof String)
         {
-            Double d = new Double((String) value);
+            Double d = Double.valueOf((String) value);
             put(key, d);
             return d;
         }

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/ArithmeticTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/ArithmeticTestCase.java
@@ -199,8 +199,8 @@ public class ArithmeticTestCase extends TestCase
  *
  *        long start = System.currentTimeMillis();
  *
- *        Number v1 = new Long (1000);
- *        Number v2 = new Double (10.23);
+ *        Number v1 = Long.valueOf(1000);
+ *        Number v2 = Double.valueOf(10.23);
  *        Number result = null;
  *        for (int a = 0; a < 10000; a++)
  *        {

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/CommonsExtPropTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/CommonsExtPropTestCase.java
@@ -101,31 +101,31 @@ public class CommonsExtPropTestCase extends BaseTestCase
             result.write("\n\n");
 
             message(result, "Testing getBoolean(key) ...");
-            result.write(Boolean.valueOf(c.getBoolean("config.boolean.value")).toString());
+            result.write(Boolean.toString(c.getBoolean("config.boolean.value")));
             result.write("\n\n");
 
             message(result, "Testing getByte(key) ...");
-            result.write(new Byte(c.getByte("config.byte.value")).toString());
+            result.write(Byte.toString(c.getByte("config.byte.value")));
             result.write("\n\n");
 
             message(result, "Testing getShort(key) ...");
-            result.write(new Short(c.getShort("config.short.value")).toString());
+            result.write(Short.toString(c.getShort("config.short.value")));
             result.write("\n\n");
 
             message(result, "Testing getInt(key) ...");
-            result.write(new Integer(c.getInt("config.int.value")).toString());
+            result.write(Integer.toString(c.getInt("config.int.value")));
             result.write("\n\n");
 
             message(result, "Testing getLong(key) ...");
-            result.write(new Long(c.getLong("config.long.value")).toString());
+            result.write(Long.toString(c.getLong("config.long.value")));
             result.write("\n\n");
 
             message(result, "Testing getFloat(key) ...");
-            result.write(new Float(c.getFloat("config.float.value")).toString());
+            result.write(Float.toString(c.getFloat("config.float.value")));
             result.write("\n\n");
 
             message(result, "Testing getDouble(key) ...");
-            result.write(new Double(c.getDouble("config.double.value")).toString());
+            result.write(Double.toString(c.getDouble("config.double.value")));
             result.write("\n\n");
 
             message(result, "Testing escaped-comma scalar...");

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/IntrospectorTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/IntrospectorTestCase.java
@@ -88,7 +88,7 @@ public class IntrospectorTestCase extends BaseTestCase
             throws Exception
     {
         // Test byte primitive.
-        Object[] byteParams = { new Byte("1") };
+        Object[] byteParams = { Byte.valueOf("1")};
         String type = "byte";
         Method method = introspector.getMethod(
                 MethodProvider.class, type + "Method", byteParams);

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/NumberMethodCallsTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/NumberMethodCallsTestCase.java
@@ -83,8 +83,8 @@ public class NumberMethodCallsTestCase extends TestCase
         vc.put("Test",new NumberMethods());
 
         // numbers for context
-        vc.put("AByte",new Byte("10"));
-        vc.put("AShort",new Short("10"));
+        vc.put("AByte", Byte.valueOf("10"));
+        vc.put("AShort", Short.valueOf("10"));
         vc.put("AInteger", 10);
         vc.put("ALong", 10L);
         vc.put("ADouble", 10.0);

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/util/introspection/ClassMapTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/util/introspection/ClassMapTestCase.java
@@ -64,13 +64,13 @@ public class ClassMapTestCase
 
         ClassMap c = new ClassMap(TestClassMap.class, log);
         assertNotNull(c.findMethod("setBoolean",   new Object[] { Boolean.TRUE }));
-        assertNotNull(c.findMethod("setByte",      new Object[] { new Byte((byte) 4)}));
-        assertNotNull(c.findMethod("setCharacter", new Object[] { new Character('c')}));
-        assertNotNull(c.findMethod("setDouble",    new Object[] { new Double(8.0) }));
-        assertNotNull(c.findMethod("setFloat",     new Object[] { new Float(15.0) }));
-        assertNotNull(c.findMethod("setInteger",   new Object[] { new Integer(16) }));
-        assertNotNull(c.findMethod("setLong",      new Object[] { new Long(23) }));
-        assertNotNull(c.findMethod("setShort",     new Object[] { new Short((short)42)}));
+        assertNotNull(c.findMethod("setByte",      new Object[] { (byte) 4 }));
+        assertNotNull(c.findMethod("setCharacter", new Object[] { 'c' }));
+        assertNotNull(c.findMethod("setDouble",    new Object[] { 8.0 }));
+        assertNotNull(c.findMethod("setFloat",     new Object[] { 15.0f }));
+        assertNotNull(c.findMethod("setInteger",   new Object[] { 16 }));
+        assertNotNull(c.findMethod("setLong",      new Object[] { 23L }));
+        assertNotNull(c.findMethod("setShort",     new Object[] { (short)42 }));
     }
 
     public static final class TestClassMap


### PR DESCRIPTION
These constructors are [deprecated for removal](https://bugs.openjdk.org/browse/JDK-8254324).