### PR TITLE
Support Java 16 records in property lookup

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/PropertyExecutor.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/PropertyExecutor.java
@@ -119,6 +119,16 @@ public class PropertyExecutor extends AbstractExecutor
 
                 setMethod(introspector.getMethod(clazz, sb.toString(), params));
             }
+
+            if (!isAlive())
+            {
+                /*
+                 * If no JavaBean property was found, try the convention used by Java 16 records.
+                 * No convenience case flip because the more convenient lowerCamelCase is also the
+                 * more likely to be used in the record itself.
+                 */
+                setMethod(introspector.getMethod(clazz, property, params));
+            }
         }
         /*
          * pass through application level runtime exceptions

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/UberspectorTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/UberspectorTestCase.java
@@ -199,6 +199,11 @@ public class UberspectorTestCase
         getter = u.getPropertyGet(uto, "Premium", null);
         assertNotNull(getter);
         assertEquals("Found wrong method", "getpremium", getter.getMethodName());
+
+        // recordField()
+        getter = u.getPropertyGet(uto, "recordField", null);
+        assertNotNull(getter);
+        assertEquals("Found wrong method", "recordField", getter.getMethodName());
     }
 
     public void testBooleanGetters()

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/misc/UberspectorTestObject.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/misc/UberspectorTestObject.java
@@ -33,6 +33,8 @@ public class UberspectorTestObject
 
     private String unambiguous;
 
+    private final String recordField = "";
+
     /**
      * @return the premium
      */
@@ -129,5 +131,9 @@ public class UberspectorTestObject
     public void setUnambiguous(Map unambiguous)
     {
         this.unambiguous = unambiguous.toString();
+    }
+
+    public String recordField() {
+        return this.recordField;
     }
 }


### PR DESCRIPTION
Java 16 records (JEP 395) are a perfect fit for Velocity variables: they are lightweight and desgined to contain immutable data. However, records don’t follow the JavaBean convention: the getter of the field `foo` is `foo()`, not `getFoo()`. Add support for this naming convention.

While this naming convention is mostly useful in projects using Java 16 records, the patch itself doesn’t rely on records, so it doesn’t break Java 1.8 compatibility.