### PR TITLE
Add a new compatibility flag for integer ranges immutability

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/RuntimeConstants.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/RuntimeConstants.java
@@ -456,6 +456,9 @@ public interface RuntimeConstants extends DeprecatedRuntimeConstants
     /** Switch for the interpolation facility for string literals. */
     String INTERPOLATE_STRINGLITERALS = "runtime.interpolate_string_literals";
 
+    /** Switch for the immutability of integer ranges. */
+    String IMMUTABLE_RANGES = "runtime.immutable_ranges";
+
     /** Switch for ignoring nulls in math equations vs throwing exceptions. */
     String STRICT_MATH = "runtime.strict_math";
 

--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/ASTIntegerRange.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/ASTIntegerRange.java
@@ -22,12 +22,15 @@ package org.apache.velocity.runtime.parser.node;
 import org.apache.velocity.context.InternalContextAdapter;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.TemplateInitException;
+import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.parser.Parser;
 import org.apache.velocity.util.DuckType;
 import org.apache.velocity.util.StringUtils;
 
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 
 /**
@@ -275,10 +278,31 @@ public class ASTIntegerRange extends SimpleNode
         int delta = ( l >= r ) ? -1 : 1;
 
         /*
-         * Return the corresponding integer range
+         * Build the corresponding integer range
          */
 
-        return new IntegerRange(l, r, delta);
+        IntegerRange range = new IntegerRange(l, r, delta);
+
+        /*
+         * Returns the range, or a concrete list if mutable ranges are requested by the configuration
+         */
+
+        boolean immutable = rsvc.getBoolean(RuntimeConstants.IMMUTABLE_RANGES, true);
+        if (immutable)
+        {
+            return range;
+        }
+        else
+        {
+            // backward compatible behavior: the list is instanciated in memory
+            int n = Math.abs(r - l) + 1;
+            List mutableRange = new ArrayList<>(n);
+            for (Iterator<Integer> it = range.iterator(); it.hasNext();)
+            {
+                mutableRange.add(it.next());
+            }
+            return mutableRange;
+        }
     }
 
     /**

--- a/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
+++ b/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
@@ -150,6 +150,15 @@ runtime.interpolate_string_literals = true
 
 
 # ----------------------------------------------------------------------------
+# INTEGER RANGES
+# ----------------------------------------------------------------------------
+# Whether integer ranges created with [a..b] expressions are immutable.
+# ON by default :)
+# ----------------------------------------------------------------------------
+runtime.immutable_ranges = true
+
+
+# ----------------------------------------------------------------------------
 # RESOURCE MANAGEMENT
 # ----------------------------------------------------------------------------
 # Allows alternative ResourceManager and ResourceCache implementations

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/BaseTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/BaseTestCase.java
@@ -204,8 +204,16 @@ public abstract class BaseTestCase extends TestCase implements TemplateTestBase
      */
     protected void assertEvalEquals(String expected, String template)
     {
+        assertEvalEquals(expected, template, engine);
+    }
+
+    /**
+     * Ensure that a template renders as expected against the provided engine.
+     */
+    protected void assertEvalEquals(String expected, String template, VelocityEngine ve)
+    {
         info("Expectation: "+expected);
-        assertEquals(expected, evaluate(template));
+        assertEquals(expected, evaluate(template, ve));
     }
 
     /**
@@ -229,6 +237,14 @@ public abstract class BaseTestCase extends TestCase implements TemplateTestBase
      */
     protected Exception assertEvalException(String evil, Class<?> exceptionType)
     {
+        return assertEvalException(evil, exceptionType, engine);
+    }
+
+    /**
+     * Ensure that a specified type of exception occurs when evaluating the string with the provided engine.
+     */
+    protected Exception assertEvalException(String evil, Class<?> exceptionType, VelocityEngine ve)
+    {
         try
         {
             if (!DEBUG)
@@ -243,7 +259,7 @@ public abstract class BaseTestCase extends TestCase implements TemplateTestBase
             {
                 info("Expectation: "+Exception.class.getName());
             }
-            evaluate(evil);
+            evaluate(evil, ve);
             String msg = "Template '"+evil+"' should have thrown an exception.";
             info("Fail: "+msg);
             fail(msg);
@@ -300,6 +316,14 @@ public abstract class BaseTestCase extends TestCase implements TemplateTestBase
      */
     protected String evaluate(String template)
     {
+        return evaluate(template, engine);
+    }
+
+    /**
+     * Evaluate the specified String as a template against the provided engine and return the result as a String.
+     */
+    protected String evaluate(String template, VelocityEngine ve)
+    {
         StringWriter writer = new StringWriter();
         try
         {
@@ -308,7 +332,7 @@ public abstract class BaseTestCase extends TestCase implements TemplateTestBase
             // use template as its own name, since our templates are short
             // unless it's not that short, then shorten it...
             String name = (template.length() <= 15) ? template : template.substring(0,15);
-            engine.evaluate(context, writer, name, template);
+            ve.evaluate(context, writer, name, template);
 
             String result = writer.toString();
             info("Result: "+result);

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/IntegerRangeMutabilityTest.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/IntegerRangeMutabilityTest.java
@@ -1,0 +1,46 @@
+package org.apache.velocity.test;
+
+import junit.framework.TestSuite;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.exception.MethodInvocationException;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
+import org.junit.Test;
+
+/**
+ * Testing mutable and immutable integer ranges. Note that this test assumes that the test executions is not done in parallel.
+ */
+
+public class IntegerRangeMutabilityTest  extends BaseTestCase {
+
+    public static junit.framework.Test suite()
+    {
+        return new TestSuite(IntegerRangeMutabilityTest.class);
+    }
+
+    public IntegerRangeMutabilityTest(String name) {
+        super(name);
+    }
+
+    @Test
+    public void testImmutableRange()
+    {
+        VelocityEngine ve = createEngine();
+        ve.init();
+
+        Exception e = assertEvalException("#set($range = [1..2])#set($range[0] = 4)", MethodInvocationException.class, ve);
+        Throwable cause = e.getCause();
+        assertNotNull(cause);
+        assertEquals(UnsupportedOperationException.class, cause.getClass());
+    }
+
+    @Test
+    public void testMutableRange()
+    {
+        VelocityEngine ve = createEngine();
+        ve.setProperty(RuntimeConstants.IMMUTABLE_RANGES, false);
+        ve.init();
+
+        assertEvalEquals("4", "#set($range = [1..2])#set($range[0] = 4)$range[0]", ve);
+    }
+}


### PR DESCRIPTION
Whereas the range operator `[x..y]` produces an immutable list since 2.1, some use cases require the range operator to return a mutable list.

This PR introduces the new backward compatibility flag `runtime.immutable_ranges`, true by default.
