### PR TITLE
Fix overzealous string to number conversion in comparison

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/ASTComparisonNode.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/ASTComparisonNode.java
@@ -76,7 +76,10 @@ public abstract class ASTComparisonNode extends ASTBinaryOperator
         {
             return compareNull(left, right);
         }
-        Boolean result = compareNumbers(left, right);
+        Boolean result = null;
+        if (!(left instanceof String) || !(right instanceof String)) {
+            result = compareNumbers(left, right);
+        }
         if (result == null)
         {
             result = compareNonNumber(left, right);


### PR DESCRIPTION
The comparison

```
#if ( '1' == '1.0' )
```

should stick to comparing strings and return false.
 
