### PR TITLE
Introspection should use the top-most public declaration of methods

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/util/introspection/ClassMap.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/util/introspection/ClassMap.java
@@ -184,6 +184,7 @@ public class ClassMap
                 int modifiers = method.getModifiers();
                 if (Modifier.isPublic(modifiers))
                 {
+                    method = MethodMap.getTopMostMethodDeclaration(method);
                     methodCache.put(method);
                 }
             }

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
@@ -46,13 +46,48 @@ public class Velocity952TestCase extends BaseTestCase
         assertEquals(TimeZone.class, getOffset.getDeclaringClass());
     }
 
+    public interface Foo
+    {
+        default String foo() { return "foo"; }
+    }
+
+    public static class Bar implements Foo
+    {
+        @Override
+        public String foo()
+        {
+            return "bar";
+        }
+    }
+
+    public static class Baz extends Bar
+    {
+        @Override
+        public String foo()
+        {
+            return "baz";
+        }
+    }
+
     protected void setUpContext(VelocityContext context)
     {
         context.put("tz", TimeZone.getDefault());
+        context.put("bar", new Bar());
+        context.put("baz", new Baz());
     }
 
     public void testEnd2End()
     {
         assertEvalEquals("3600000", "$tz.getOffset(1)");
+    }
+
+    public void testBar()
+    {
+        assertEvalEquals("bar", "$bar.foo()");
+    }
+
+    public void testBaz()
+    {
+        assertEvalEquals("baz", "$baz.foo()");
     }
 }

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
@@ -1,0 +1,58 @@
+package org.apache.velocity.test.issues;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.test.BaseTestCase;
+import org.apache.velocity.util.introspection.ClassMap;
+import org.apache.velocity.util.introspection.MethodMap;
+
+import java.lang.reflect.Method;
+import java.util.TimeZone;
+
+/**
+ * This class tests the fix for VELOCITY-952.
+ */
+public class Velocity952TestCase extends BaseTestCase
+{
+    public Velocity952TestCase(String name)
+    {
+       super(name);
+    }
+
+    public void testMethodMap()
+    {
+        ClassMap classMap = new ClassMap(TimeZone.getDefault().getClass(), Velocity.getLog());
+        Method getOffset = classMap.findMethod("getOffset", new Object[] { 1L });
+        assertNotNull(getOffset);
+        assertEquals(TimeZone.class, getOffset.getDeclaringClass());
+    }
+
+    protected void setUpContext(VelocityContext context)
+    {
+        context.put("tz", TimeZone.getDefault());
+    }
+
+    public void testEnd2End()
+    {
+        assertEvalEquals("3600000", "$tz.getOffset(1)");
+    }
+}


### PR DESCRIPTION
Some classes which are not exported do implement public interfaces.

For instance, `sun.util.calendar.ZoneInfo.getOffset(long)` implements the public interface method `java.util.TimeZone.getOffset(long)`.

To avoid illegal access exceptions, the introspector should use the top-most public declaration of methods.
