### PR TITLE
Fix time zone issue in Velocity952TestCase

### DIFF
--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/issues/Velocity952TestCase.java
@@ -83,7 +83,7 @@ public class Velocity952TestCase extends BaseTestCase
 
     protected void setUpContext(VelocityContext context)
     {
-        context.put("tz", TimeZone.getDefault());
+        context.put("tz", TimeZone.getTimeZone("GMT+1"));
         context.put("bar", new Bar());
         context.put("baz", new Baz());
     }


### PR DESCRIPTION
Fix issue where testEnd2End fails when run outside of the GMT+1 time zone.