### PR TITLE
[VELOCITY-986] Fixed issues when the map has its methods as keys like size and values

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/PropertyExecutor.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/PropertyExecutor.java
@@ -26,6 +26,7 @@ import org.apache.velocity.util.introspection.Introspector;
 import org.slf4j.Logger;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 
 /**
  * Returned the value of object property when executed.
@@ -120,7 +121,9 @@ public class PropertyExecutor extends AbstractExecutor
                 setMethod(introspector.getMethod(clazz, sb.toString(), params));
             }
 
-            if (!isAlive())
+            // Check if no valid method was found and
+            // the class is not a Map before trying record-style property access
+            if (!isAlive() && !Map.class.isAssignableFrom(clazz))
             {
                 /*
                  * If no JavaBean property was found, try the convention used by Java 16 records.

--- a/velocity-engine-core/src/test/java/org/apache/velocity/test/UberspectorTestCase.java
+++ b/velocity-engine-core/src/test/java/org/apache/velocity/test/UberspectorTestCase.java
@@ -28,7 +28,9 @@ import org.apache.velocity.util.introspection.Uberspect;
 import org.apache.velocity.util.introspection.VelPropertyGet;
 import org.apache.velocity.util.introspection.VelPropertySet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -282,6 +284,28 @@ public class UberspectorTestCase
         setter = u.getPropertySet(uto, "unambiguous", new HashMap(), null);
         assertNotNull(setter);
         setter.invoke(uto, new HashMap());
+    }
+
+    public void testMapDefaultMethods() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        List<Integer> list = new ArrayList<>();
+        list.add(1);
+        map.put("values", list);
+        map.put("size", "6Feet");
+
+        Uberspect u = ri.getUberspect();
+
+        VelPropertyGet valuesGetter = u.getPropertyGet(map, "values", null);
+        Object valuesObj = valuesGetter.invoke(map);
+        assertNotNull(valuesGetter);
+        assertTrue(valuesObj instanceof ArrayList);
+        assertEquals(list, valuesObj);
+
+        VelPropertyGet sizeGetter = u.getPropertyGet(map, "size", null);
+        Object sizeObj = sizeGetter.invoke(map);
+        assertNotNull(sizeGetter);
+        assertTrue(sizeObj instanceof String);
+        assertEquals("6Feet", sizeObj);
     }
 
     /*


### PR DESCRIPTION
**Problem:**

After adding a new feature to support Java 16 record-style properties (see this PR: https://github.com/apache/velocity-engine/pull/45), we are seeing an issue when using a Map that has keys with the same names as method names.

Here is an example:

```
Map<String, Object> map = new HashMap<>();
List<Integer> list = new ArrayList<>();
list.add(1);
map.put("values", list);
map.put("size", "6Feet");
```

In this example:

1.  When we try to get values, we expect to get the list [1], but instead we get all values from the map - [[1],"6Feet"]. This happens because it's calling the map.values() method, not the "values" key.
2.  When we try to get size, we expect to get "6Feet", but we get 2 instead, because it's calling the map. Size() method.

**Reported issues:** 

Issue1: [VELOCITY-986](https://issues.apache.org/jira/browse/VELOCITY-986)
Issue2: https://github.com/apache/velocity-engine/pull/45#discussion_r2225914086

**Solution:**

To fix this, we should skip or ignore Map objects when using the Java 16 record-style property feature. That way, it will get the actual values from the map keys, not from the methods.
