### PR TITLE
TRUNK-5119 : Added backward compatability lines to velocity.properties file

### DIFF
--- a/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
+++ b/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
@@ -44,7 +44,7 @@ directive.foreach.max_loops = -1
 # as long as zero numbers, do evaluate to false.
 # ----------------------------------------------------------------------------
 
-directive.if.empty_check = true
+directive.if.empty_check = false
 
 # ----------------------------------------------------------------------------
 # P A R S E  P R O P E R T I E S
@@ -206,7 +206,7 @@ introspector.uberspect.class = org.apache.velocity.util.introspection.UberspectI
 # Sets the data types Conversion Handler used by the default uberspector
 # ----------------------------------------------------------------------------
 
-introspector.conversion_handler.class = org.apache.velocity.util.introspection.TypeConversionHandlerImpl
+introspector.conversion_handler.class = none
 1
 
 # ----------------------------------------------------------------------------
@@ -248,7 +248,7 @@ introspector.restrict.classes = javax.script.ScriptEngine
 # Possible values: none, bc (aka Backward Compatible), lines, structured
 # ----------------------------------------------------------------------------
 
-parser.space_gobbling = lines
+parser.space_gobbling = bc
 
 # ----------------------------------------------------------------------------
 # HYPHEN IN IDENTIFIERS
@@ -256,4 +256,7 @@ parser.space_gobbling = lines
 # Set to true to allow '-' in reference identifiers (backward compatibility option)
 # ----------------------------------------------------------------------------
 
-parser.allow_hyphen_in_identifiers = false
+parser.allow_hyphen_in_identifiers = true
+
+# When displaying null arguments literals, use provided arguments literals (since 2.1)
+velocimacro.arguments.preserve_literals = true

--- a/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
+++ b/velocity-engine-core/src/main/resources/org/apache/velocity/runtime/defaults/velocity.properties
@@ -127,8 +127,7 @@ velocimacro.body_reference = bodyContent
 # without an explicit default value is missing from the macro call, its value
 # will be looked up in the global context
 # ----------------------------------------------------------------------------
-velocimacro.enable_bc_mode = false
-
+velocimacro.enable_bc_mode = true
 # ----------------------------------------------------------------------------
 # STRICT REFERENCE MODE
 # ----------------------------------------------------------------------------
@@ -258,5 +257,5 @@ parser.space_gobbling = bc
 
 parser.allow_hyphen_in_identifiers = true
 
-# When displaying null arguments literals, use provided arguments literals (since 2.1)
+# When displaying null arguments literals, use provided arguments literals
 velocimacro.arguments.preserve_literals = true


### PR DESCRIPTION
Regarding the issue TRUNK-5119, 
https://openmrs.atlassian.net/issues?filter=10665&selectedIssue=TRUNK-5119
I checked if velocity versions are already updated though out the project. And found they are already updated.
1. Velocity version: 2.5-SNAPSHOT (already beyond 2.0/2.1)
2. Java requirement: Java 8+ (documented in README)
3. SLF4J logging: Already integrated in the parent

To maximize backward compatibility of Velocity 2.5 with Velocity 1.x, I have include the 4 lines in your Velocity configuration as mentioned in this link in the main folder velocity-engine\velocity-engine-core\src\main\resources\org\apache\velocity\runtime\default\velocity.properties :
I also modified velocimacro.enable_bc_mode = true as it was conflicting with the above configuration.
I have tested locally to ensure build was success.
https://velocity.apache.org/engine/2.1/upgrading.html#dependencies-changes

<img width="1102" height="638" alt="velocity" src="https://github.com/user-attachments/assets/ce4ca060-fc9f-482a-824b-1385b27c9295" />

