### PR TITLE
VELOCITY-996 Fix precision loss in BigDecimal conversion

### DIFF
--- a/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/MathUtils.java
+++ b/velocity-engine-core/src/main/java/org/apache/velocity/runtime/parser/node/MathUtils.java
@@ -109,6 +109,11 @@ public abstract class MathUtils
             return new BigDecimal ( (BigInteger)n );
         }
 
+        if (n instanceof Long)
+        {
+            return new BigDecimal(n.longValue());
+        }
+
         return BigDecimal.valueOf(n.doubleValue());
 
     }


### PR DESCRIPTION
## Problem

`MathUtils.toBigDecimal(Number)` currently converts generic `Number` instances through `doubleValue()` before creating a `BigDecimal`.

This can lose precision for large integral values, for example `Long.MAX_VALUE`.

As a result, VTL arithmetic and comparisons involving a `Long` and a `BigDecimal` may produce unexpected results.

## Example

```vtl
#set($L  = 9223372036854775807)  ## Long.MAX_VALUE
#set($BI = 9223372036854775808)  ## BigInteger

#set($BD0 = ($BI + 0.0) - $BI)  ## BigDecimal 0.0
#set($BDL = $BI - 1.0)          ## BigDecimal 9223372036854775807.0

#set($d = $L + $BD0)
L + BigDecimal(0.0)       = $d ($d.class.name)

L == BigDecimal(Long.MAX) = #if($L == $BDL)true#{else}false#end
L >  BigDecimal(Long.MAX) = #if($L >  $BDL)true#{else}false#end
vtl```

